### PR TITLE
Apici doppi mancanti

### DIFF
--- a/wp-banner-cookie-law.php
+++ b/wp-banner-cookie-law.php
@@ -54,8 +54,8 @@ function wp_head_cookie_banner_options()
                 showPreferencesOption : <?php echo get_clb_showPreferencesOption_option(); ?> ,
                 showStatisticsOption : <?php echo get_clb_showStatisticsOption_option(); ?> ,
                 showMarketingOption : <?php echo get_clb_showMarketingOption_option(); ?> ,
-                managePreferencesButtonText: <?php echo get_clb_managePreferencesButtonText_option(); ?> ,
-                savePreferencesButtonText: <?php echo get_clb_savePreferencesButtonText_option(); ?> ,
+                managePreferencesButtonText: "<?php echo get_clb_managePreferencesButtonText_option(); ?>" ,
+                savePreferencesButtonText: "<?php echo get_clb_savePreferencesButtonText_option(); ?>" ,
                 styles : {
                     <?php echo get_clb_styles(); ?>
                 },


### PR DESCRIPTION
Penso che manchino degli apici doppi attorno agli attributi managePreferencesButtonText e savePreferencesButtonText